### PR TITLE
Refactor Builder.io initialization to client-side

### DIFF
--- a/src/app/ClientBuilder.tsx
+++ b/src/app/ClientBuilder.tsx
@@ -1,6 +1,18 @@
 'use client';
-import { BuilderComponent } from '@builder.io/react';
+import { useEffect } from 'react';
+import { builder, BuilderComponent } from '@builder.io/react';
+
+const BUILDER_API_KEY = 'f4f23be0b5024386a74bae0866060e0c';
 
 export default function ClientBuilder({ content }: { content: any }) {
-  return <BuilderComponent model="page" content={content} />;
+  useEffect(() => {
+    // Initialize builder client-side
+    try {
+      builder.init(BUILDER_API_KEY);
+    } catch (e) {
+      // ignore initialization errors
+    }
+  }, []);
+
+  return <BuilderComponent model="page" content={content ?? undefined} />;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,24 @@
-import { builder } from '@builder.io/react';
 import ClientBuilder from './ClientBuilder';
 import '@/styles/tokens.css';
 
-builder.init('f4f23be0b5024386a74bae0866060e0c'); // your public API key
+const BUILDER_API_KEY = 'f4f23be0b5024386a74bae0866060e0c';
+
+async function fetchBuilderPage(urlPath: string) {
+  const url = `https://cdn.builder.io/api/v3/content/page?apiKey=${BUILDER_API_KEY}&limit=1&userAttributes.url=${encodeURIComponent(
+    urlPath
+  )}`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const json = await res.json();
+    return json?.results?.[0] ?? null;
+  } catch (err) {
+    return null;
+  }
+}
 
 export default async function Page() {
-  const content = await builder.get('page', { url: '/' }).toPromise();
+  const content = await fetchBuilderPage('/');
 
   return (
     <main>


### PR DESCRIPTION
## Changes Made

### ClientBuilder.tsx
- Added `useEffect` import from React
- Added `builder` import from `@builder.io/react`
- Added `BUILDER_API_KEY` constant
- Implemented client-side Builder.io initialization in `useEffect` hook with error handling
- Updated content prop handling to use nullish coalescing (`content ?? undefined`)

### page.tsx
- Removed server-side `builder.init()` call
- Removed `builder` import from `@builder.io/react`
- Added `BUILDER_API_KEY` constant
- Replaced `builder.get()` with custom `fetchBuilderPage()` function
- Implemented direct API fetch using Builder.io CDN endpoint
- Added error handling for failed API requests

## Summary
This refactoring moves Builder.io initialization from server-side to client-side and replaces the Builder SDK's `get()` method with direct API calls for better control over data fetching.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/80f8ef8fee9544ffa799010f76e34072/swoosh-zone)

👀 [Preview Link](https://80f8ef8fee9544ffa799010f76e34072-swoosh-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>80f8ef8fee9544ffa799010f76e34072</projectId>-->
<!--<branchName>swoosh-zone</branchName>-->